### PR TITLE
Fix AndroidManifest: remove unnecessary information

### DIFF
--- a/UsergridAndroidSDK/src/main/AndroidManifest.xml
+++ b/UsergridAndroidSDK/src/main/AndroidManifest.xml
@@ -7,11 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
When trying to use usergrid-android in my app, I found manifest merger errors. This fix remove some AndroidManifest tags, so it can be merged with (potentially) any project.